### PR TITLE
Defaulting current_windows when transfering character preferences (bug in an another branching build)

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -476,6 +476,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 
 /// Sanitizes the preferences, applies the randomization prefs, and then applies the preference to the human mob.
 /datum/preferences/proc/safe_transfer_prefs_to(mob/living/carbon/human/character, icon_updates = TRUE, is_antag = FALSE)
+	current_window = PREFERENCE_TAB_CHARACTER_PREFERENCES
 	apply_character_randomization_prefs(is_antag)
 	apply_prefs_to(character, icon_updates)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR defaults "current_window" value when transferring character preferences when spawning with "safe_transfer_prefs_to", such as roundstart or latejoin.

There is currently a bug on Skyrat branch, which spawns characters with random default human due to "current_window" not being a default value.
To reproduce the bug, one should just open Game Preferences once, and to fix it, they need to open Character Setup.

I didn't find a better place to default the value (while not closing the "Game Preferences" window), so here it is.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes an unpleasant bug with spawning on random character on other builds (Skyrat specifically), which base on TG.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Defaults "current_window" value when transferring character preferences when spawning with "safe_transfer_prefs_to"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
